### PR TITLE
Fix crash when initializing canvas without saved state

### DIFF
--- a/src/features/editor/hooks/use-load-state.ts
+++ b/src/features/editor/hooks/use-load-state.ts
@@ -20,6 +20,26 @@ export const useLoadState = ({
 }: UseLoadStateProps) => {
   const initialized = useRef(false);
 
+  const renderCanvas = (target: fabric.Canvas | null) => {
+    if (!target?.contextContainer) {
+      return;
+    }
+
+    target.renderAll();
+  };
+
+  const clearCanvasObjects = (target: fabric.Canvas | null) => {
+    if (!target) return;
+
+    const objects = target.getObjects();
+
+    objects
+      .filter((object) => object.name !== "clip")
+      .forEach((object) => target.remove(object));
+
+    target.discardActiveObject();
+  };
+
   useEffect(() => {
     if (!initialized.current && initialState?.current && canvas) {
       const data = JSON.parse(initialState.current);
@@ -31,6 +51,18 @@ export const useLoadState = ({
         setHistoryIndex(0);
         autoZoom();
       });
+      initialized.current = true;
+      return;
+    }
+
+    if (!initialized.current && canvas) {
+      clearCanvasObjects(canvas);
+      renderCanvas(canvas);
+
+      const currentSnapshot = JSON.stringify(canvas.toJSON(JSON_KEYS));
+      canvasHistory.current = [currentSnapshot];
+      setHistoryIndex(0);
+      autoZoom();
       initialized.current = true;
     }
   }, [


### PR DESCRIPTION
## Summary
- ensure the editor canvas clears objects safely when no stored state is available
- guard canvas rendering to avoid calling renderAll on a disposed context and initialize history/zoom for a fresh canvas

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3c6672c908325887abfd2baed60e8